### PR TITLE
Add JavaScript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 out
 node_modules
+package-lock.json
+*.vsix
+.vscode-test

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ doSomething();
 This extension automatically converts any imports of the first format to the second format when
 you save the file.
 
-It runs on any .ts or .tsx files that are nested inside a 'packages' directory.
+It runs on any .ts .tsx or .js files that are nested inside a 'packages' directory.
 
 ## Usage
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,12 @@ import { window, workspace, commands, Disposable, ExtensionContext, TextDocument
 import { dirname, join, resolve, relative } from "path";
 import { existsSync, readFileSync } from "fs";
 
+const isTypescript = languageId => languageId === "typescript" || languageId === "typescriptreact";
+
+const isJavascript = languageId => languageId === "javascript" || languageId === "javascriptreact";
+
+const isSupportedLanguage = ({languageId}) => isTypescript(languageId) || isJavascript(languageId)
+
 // this method is called when your extension is activated. activation is
 // controlled by the activation events defined in package.json
 export function activate(ctx: ExtensionContext) {
@@ -28,9 +34,7 @@ export class ImportFixer {
             return;
         }
 
-        const isTypescript = doc.languageId === "typescript" || doc.languageId === "typescriptreact";
-
-        if (!isTypescript) {
+        if (!isSupportedLanguage(doc)) {
             return;
         }
 


### PR DESCRIPTION
Adds support for files with language of `javascript` or `javascriptreact`

Notes: 
- I refactored the language detection out to a helper. 
- I can't find anything else that is ts-specific.
- I added build artifacts to the `.gitignore` (which I'm assuming you have included in your global `.gitignore`).

Closes #2