### PR TITLE
feat: supporting search of double and single quotes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,9 +42,9 @@ export class ImportFixer {
 
         const packagesDirectory = packagesDirectoryMatch[1];
         const pathToPackagesDirectory = relative(dirname(doc.fileName), packagesDirectory);
-        const packageNameRegex = "[^\"\/\.]*";
-        const importPathRegex = escapeRegExp(pathToPackagesDirectory) + "\/" + packageNameRegex + "\/" + "[^\"]*";
-        const importRegex = new RegExp("from \"(" + importPathRegex + ")\";\n", "g");
+        const packageNameRegex = "[^\"\'\/\.]*";
+        const importPathRegex = escapeRegExp(pathToPackagesDirectory) + "\/" + packageNameRegex + "\/" + "[^\"\']*";
+        const importRegex = new RegExp("from [\"\'](" + importPathRegex + ")[\"\'];\n", "g");
         let match = importRegex.exec(doc.getText());
         editor.edit(builder => {
             while (match != null) {


### PR DESCRIPTION
The current regex only matches against double-quoted imports such as:

```ts
import package from "../../../package_name/src"
```

This change allows matching for imports with single-quotes such as:

```ts
import package from '../../../package_name/src'
```

It should be noted that the output is still double-quoted, so the result of the above would be as follow:

```ts
import package from "@scope/package_name"
```

This can be rectified by other plugins.